### PR TITLE
Support Windows 7 by downgrading Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "reblessive"
 version = "0.3.5"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.75"
 license = "MIT"
 readme = "README.md"
 description = "A small runtime for running deeply nested recursive functions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "reblessive"
 version = "0.3.5"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.75.0"
 license = "MIT"
 readme = "README.md"
 description = "A small runtime for running deeply nested recursive functions"


### PR DESCRIPTION
I was trying to build SurrealDB for Windows 7 32-bit and I couldn't because `reblessive` depends on Rust 1.77 for no apparent reason. If there's a reason for this, please provide it. If none, why not? 

Closes https://github.com/DelSkayn/reblessive/issues/3